### PR TITLE
Modify S/G settings for Worker, Master, and LB

### DIFF
--- a/modules/eks-compute/outputs.tf
+++ b/modules/eks-compute/outputs.tf
@@ -11,5 +11,5 @@ output "target_group_arn" {
   value = "${aws_lb_target_group.tg_http.arn}"
 }
 output "worknode_security_group_id" {
-  value = "${aws_security_group.worker.id}"
+  value = "${aws_security_group.worker-internal.id}"
 }

--- a/modules/eks-compute/resource-cluster-sg.tf
+++ b/modules/eks-compute/resource-cluster-sg.tf
@@ -1,8 +1,8 @@
 ## cluster security group
 
-resource "aws_security_group" "cluster" {
-  name        = "masters.${local.lower_name}"
-  description = "Cluster communication with worker nodes"
+resource "aws_security_group" "cluster-egress" {
+  name        = "masters.${local.lower_name}-egress"
+  description = "Cluster security group for egress rules"
 
   vpc_id = var.vpc_id
 
@@ -14,20 +14,40 @@ resource "aws_security_group" "cluster" {
   }
 
   tags = {
-    "Name"                                      = "masters.${local.lower_name}"
+    "Name"                                      = "masters.${local.lower_name}-egress"
     "kubernetes.io/cluster/${local.lower_name}" = "owned"
   }
 }
 
-resource "aws_security_group_rule" "cluster-ingress-node-https" {
-  description              = "Allow node to communicate with the cluster API Server"
-  security_group_id        = aws_security_group.cluster.id
-  source_security_group_id = aws_security_group.worker.id
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  type                     = "ingress"
+resource "aws_security_group" "cluster-ingress" {
+  name        = "masters.${local.lower_name}-ingress"
+  description = "Cluster security group for ingress rules"
+
+  vpc_id = var.vpc_id
+
+  ingress {
+    description     = "Allow node to communicate with the cluster API Server"
+    security_groups = [aws_security_group.worker-egress.id]
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+  }
+
+  tags = {
+    "Name"                                      = "masters.${local.lower_name}-ingress"
+    "kubernetes.io/cluster/${local.lower_name}" = "owned"
+  }
 }
+
+# resource "aws_security_group_rule" "cluster-ingress-node-https" {
+#   description              = "Allow node to communicate with the cluster API Server"
+#   security_group_id        = aws_security_group.cluster.id
+#   source_security_group_id = aws_security_group.worker.id
+#   from_port                = 443
+#   to_port                  = 443
+#   protocol                 = "tcp"
+#   type                     = "ingress"
+# }
 
 # resource "aws_security_group_rule" "cluster-ingress-admin-https" {
 #   description       = "Allow workstation to communicate with the cluster API Server"

--- a/modules/eks-compute/resource-cluster-sg.tf
+++ b/modules/eks-compute/resource-cluster-sg.tf
@@ -1,7 +1,7 @@
 ## cluster security group
 
-resource "aws_security_group" "cluster-egress" {
-  name        = "masters.${local.lower_name}-egress"
+resource "aws_security_group" "cluster" {
+  name        = "master.${local.lower_name}"
   description = "Cluster security group for egress rules"
 
   vpc_id = var.vpc_id
@@ -13,28 +13,16 @@ resource "aws_security_group" "cluster-egress" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = {
-    "Name"                                      = "masters.${local.lower_name}-egress"
-    "kubernetes.io/cluster/${local.lower_name}" = "owned"
-  }
-}
-
-resource "aws_security_group" "cluster-ingress" {
-  name        = "masters.${local.lower_name}-ingress"
-  description = "Cluster security group for ingress rules"
-
-  vpc_id = var.vpc_id
-
   ingress {
     description     = "Allow node to communicate with the cluster API Server"
-    security_groups = [aws_security_group.worker-egress.id]
+    security_groups = [aws_security_group.worker.id]
     from_port       = 443
     to_port         = 443
     protocol        = "tcp"
   }
 
   tags = {
-    "Name"                                      = "masters.${local.lower_name}-ingress"
+    "Name"                                      = "masters.${local.lower_name}"
     "kubernetes.io/cluster/${local.lower_name}" = "owned"
   }
 }

--- a/modules/eks-compute/resource-cluster.tf
+++ b/modules/eks-compute/resource-cluster.tf
@@ -6,10 +6,11 @@ resource "aws_eks_cluster" "cluster" {
   version  = var.kubernetes_version
 
   vpc_config {
-    subnet_ids         = var.subnet_ids
+    subnet_ids = var.subnet_ids
     security_group_ids = [
-        aws_security_group.cluster.id,
-      ]
+      aws_security_group.cluster-ingress.id,
+      aws_security_group.cluster-egress.id,
+    ]
   }
 
   depends_on = [

--- a/modules/eks-compute/resource-cluster.tf
+++ b/modules/eks-compute/resource-cluster.tf
@@ -8,8 +8,7 @@ resource "aws_eks_cluster" "cluster" {
   vpc_config {
     subnet_ids = var.subnet_ids
     security_group_ids = [
-      aws_security_group.cluster-ingress.id,
-      aws_security_group.cluster-egress.id,
+      aws_security_group.cluster.id,
     ]
   }
 

--- a/modules/eks-compute/resource-worker-mixed.tf
+++ b/modules/eks-compute/resource-worker-mixed.tf
@@ -28,7 +28,8 @@ resource "aws_launch_template" "worker-mixed" {
     delete_on_termination       = true
     associate_public_ip_address = "${var.associate_public_ip_address}"
     security_groups             = [
-      aws_security_group.worker.id,
+      aws_security_group.worker-ingress.id,
+      aws_security_group.worker-egress.id,
     ]
   }
 }

--- a/modules/eks-compute/resource-worker-sg.tf
+++ b/modules/eks-compute/resource-worker-sg.tf
@@ -13,7 +13,7 @@ resource "aws_security_group" "worker" {
 }
 
 resource "aws_security_group" "worker-internal" {
-  name        = "nodes-internal.${local.lower_name}"
+  name        = "node-internal.${local.lower_name}"
   description = "Worker security group for ingress rules"
 
   vpc_id = var.vpc_id
@@ -42,7 +42,7 @@ resource "aws_security_group" "worker-internal" {
   }
 
   tags = {
-    "Name"                                      = "nodes-internal.${local.lower_name}"
+    "Name"                                      = "node-internal.${local.lower_name}"
     "kubernetes.io/cluster/${local.lower_name}" = "owned"
   }
 }

--- a/modules/securitygroup-inline/outputs.tf
+++ b/modules/securitygroup-inline/outputs.tf
@@ -1,4 +1,7 @@
 
 output "sg_id" {
-  value = "${aws_security_group.this.id}"
+  value = "${aws_security_group.node-ingress.id}"
+}
+output "svc_sg_id" {
+  value = "${aws_security_group.service.id}"
 }

--- a/modules/securitygroup-inline/resource-sg.tf
+++ b/modules/securitygroup-inline/resource-sg.tf
@@ -1,8 +1,9 @@
 # security group
 
-resource "aws_security_group" "this" {
-    name        = "${var.sg_name}.${local.lower_name}"
-    description = "${var.sg_desc}"
+# For ALB
+resource "aws_security_group" "service" {
+    name = "service.${local.lower_name}"
+    description = "Security group for load balancer"
 
     vpc_id = "${var.vpc_id}"
 
@@ -11,6 +12,43 @@ resource "aws_security_group" "this" {
         to_port     = 0
         protocol    = "-1"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "http"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "TCP"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "https"
+        from_port   = 443
+        to_port     = 443
+        protocol    = "TCP"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    tags = {
+        Name = "service.${local.lower_name}"
+        SG_Groups = "${local.lower_name}"
+
+    }
+}
+
+resource "aws_security_group" "node-ingress" {
+    name        = "${var.sg_name}.${local.lower_name}"
+    description = "${var.sg_desc}"
+
+    vpc_id = "${var.vpc_id}"
+
+    ingress {
+        description = "ALB for nginx-ingress-controller"
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        security_groups = [aws_security_group.service.id]
     }
 
     dynamic "ingress" {

--- a/templates/eks/cluster-security-group.tf
+++ b/templates/eks/cluster-security-group.tf
@@ -13,9 +13,9 @@ locals {
 }
 
 ## cluster security group
-resource "aws_security_group" "cluster-egress" {
-  name        = "masters.${local.cluster_name}-egress"
-  description = "Cluster security group for egress rules"
+resource "aws_security_group" "cluster" {
+  name        = "masters.${local.cluster_name}"
+  description = "Security group for cluster"
 
   vpc_id = local.vpc_id
 
@@ -26,21 +26,9 @@ resource "aws_security_group" "cluster-egress" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = {
-    "Name"                                        = "masters.${local.cluster_name}-egress"
-    "kubernetes.io/cluster/${local.cluster_name}" = "owned"
-  }
-}
-
-resource "aws_security_group" "cluster-ingress" {
-  name        = "masters.${local.cluster_name}-ingress"
-  description = "Cluster security group for ingress rules"
-
-  vpc_id = local.vpc_id
-
   ingress {
     description     = "Allow node to communicate with the cluster API Server"
-    security_groups = [aws_security_group.worker-egress.id]
+    security_groups = [aws_security_group.worker.id]
     from_port       = 443
     to_port         = 443
     protocol        = "tcp"
@@ -55,7 +43,7 @@ resource "aws_security_group" "cluster-ingress" {
   }
 
   tags = {
-    "Name"                                        = "masters.${local.cluster_name}-ingress"
+    "Name"                                        = "masters.${local.cluster_name}"
     "kubernetes.io/cluster/${local.cluster_name}" = "owned"
   }
 }

--- a/templates/eks/cluster.tf
+++ b/templates/eks/cluster.tf
@@ -22,7 +22,7 @@ resource "aws_eks_cluster" "cluster" {
 
   vpc_config {
     subnet_ids         = local.private_subnets
-    security_group_ids = [aws_security_group.cluster.id]
+    security_group_ids = [aws_security_group.cluster-ingress.id, aws_security_group.cluster-egress.id]
   }
 
   depends_on = [

--- a/templates/eks/worker-mixed.tf
+++ b/templates/eks/worker-mixed.tf
@@ -50,7 +50,10 @@ resource "aws_launch_template" "worker-mixed" {
   network_interfaces {
     delete_on_termination       = true
     associate_public_ip_address = false
-    security_groups             = [aws_security_group.worker-egress.id, aws_security_group.worker-igress.id]
+    security_groups             = [
+      aws_security_group.worker.id, 
+      aws_security_group.worker-internal.id,
+    ]
   }
 }
 

--- a/templates/eks/worker-mixed.tf
+++ b/templates/eks/worker-mixed.tf
@@ -50,7 +50,7 @@ resource "aws_launch_template" "worker-mixed" {
   network_interfaces {
     delete_on_termination       = true
     associate_public_ip_address = false
-    security_groups             = [aws_security_group.worker.id]
+    security_groups             = [aws_security_group.worker-egress.id, aws_security_group.worker-igress.id]
   }
 }
 

--- a/templates/eks/worker-spot.tf
+++ b/templates/eks/worker-spot.tf
@@ -44,7 +44,7 @@ resource "aws_launch_template" "worker-spot" {
   network_interfaces {
     delete_on_termination       = true
     associate_public_ip_address = false
-    security_groups             = [aws_security_group.worker.id]
+    security_groups             = [aws_security_group.worker-ingress.id, aws_security_group.worker-egress.id]
   }
 
   instance_market_options {

--- a/templates/eks/worker.tf
+++ b/templates/eks/worker.tf
@@ -30,7 +30,7 @@ resource "aws_launch_configuration" "worker" {
 
   associate_public_ip_address = false
 
-  security_groups = [aws_security_group.worker.id]
+  security_groups = [aws_security_group.worker-ingress.id, aws_security_group.worker-egress.id]
 
   root_block_device {
     volume_type           = "gp2"


### PR DESCRIPTION
- Inbound access control S/G (node-ingress) and S/G (service) for load balancers are prepared before cluster creation.
- Create a separate reference S/G (node) for the Worker.
- Create a separate S/G (node-internal) for access control within the cluster and a S/G (node-ingress) for inbound access control.
- Inline all S/G rules.