### PR TITLE
modify security group settings

### DIFF
--- a/modules/eks-compute/outputs.tf
+++ b/modules/eks-compute/outputs.tf
@@ -11,5 +11,5 @@ output "target_group_arn" {
   value = "${aws_lb_target_group.tg_http.arn}"
 }
 output "worknode_security_group_id" {
-  value = "${aws_security_group.worker.id}"
+  value = "${aws_security_group.worker-internal.id}"
 }

--- a/modules/eks-compute/resource-cluster-sg.tf
+++ b/modules/eks-compute/resource-cluster-sg.tf
@@ -1,7 +1,7 @@
 ## cluster security group
 
 resource "aws_security_group" "cluster" {
-  name        = "masters.${local.lower_name}"
+  name        = "master.${local.lower_name}"
   description = "Cluster communication with worker nodes"
 
   vpc_id = var.vpc_id
@@ -13,28 +13,17 @@ resource "aws_security_group" "cluster" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description     = "Allow node to communicate with the cluster API Server"
+    security_groups = [aws_security_group.worker.id]
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+  }
+
   tags = {
     "Name"                                      = "masters.${local.lower_name}"
     "kubernetes.io/cluster/${local.lower_name}" = "owned"
   }
 }
 
-resource "aws_security_group_rule" "cluster-ingress-node-https" {
-  description              = "Allow node to communicate with the cluster API Server"
-  security_group_id        = aws_security_group.cluster.id
-  source_security_group_id = aws_security_group.worker.id
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  type                     = "ingress"
-}
-
-# resource "aws_security_group_rule" "cluster-ingress-admin-https" {
-#   description       = "Allow workstation to communicate with the cluster API Server"
-#   security_group_id = aws_security_group.cluster.id
-#   cidr_blocks       = local.allow_ips
-#   from_port         = 443
-#   to_port           = 443
-#   protocol          = "tcp"
-#   type              = "ingress"
-# }

--- a/modules/eks-compute/resource-cluster.tf
+++ b/modules/eks-compute/resource-cluster.tf
@@ -6,10 +6,10 @@ resource "aws_eks_cluster" "cluster" {
   version  = var.kubernetes_version
 
   vpc_config {
-    subnet_ids         = var.subnet_ids
+    subnet_ids = var.subnet_ids
     security_group_ids = [
-        aws_security_group.cluster.id,
-      ]
+      aws_security_group.cluster.id,
+    ]
   }
 
   depends_on = [

--- a/modules/eks-compute/resource-worker-mixed.tf
+++ b/modules/eks-compute/resource-worker-mixed.tf
@@ -4,7 +4,7 @@ resource "aws_launch_template" "worker-mixed" {
   count = "${length(var.mixed_instances) > 0 ? 1 : 0}"
 
   name_prefix   = "${local.upper_name}-MIXED-"
-  image_id             = "${data.aws_ami.worker.id}"
+  image_id      = "${data.aws_ami.worker.id}"
   instance_type = "${var.instance_type}"
   user_data     = "${base64encode(local.userdata)}"
 
@@ -27,8 +27,10 @@ resource "aws_launch_template" "worker-mixed" {
   network_interfaces {
     delete_on_termination       = true
     associate_public_ip_address = "${var.associate_public_ip_address}"
-    security_groups             = [
+    security_groups = [
       aws_security_group.worker.id,
+      aws_security_group.worker-internal.id,
+      var.worker_sg_id, #worker-ingress.id
     ]
   }
 }
@@ -43,7 +45,7 @@ resource "aws_autoscaling_group" "worker-mixed" {
 
   vpc_zone_identifier = var.subnet_ids
 
-  enabled_metrics = [ 
+  enabled_metrics = [
     "GroupDesiredCapacity",
     "GroupInServiceInstances",
     "GroupMaxSize",
@@ -53,7 +55,7 @@ resource "aws_autoscaling_group" "worker-mixed" {
     "GroupTerminatingInstances",
     "GroupTotalInstances",
   ]
-  
+
   target_group_arns = [
     aws_lb_target_group.tg_http.arn,
   ]

--- a/modules/eks-compute/resource-worker-sg.tf
+++ b/modules/eks-compute/resource-worker-sg.tf
@@ -1,8 +1,20 @@
 # worker security group
 
 resource "aws_security_group" "worker" {
-  name        = "nodes.${local.lower_name}"
-  description = "Security group for all worker nodes in the cluster"
+  name        = "node.${local.lower_name}"
+  description = "A security group to prevent cross-reference."
+
+  vpc_id = var.vpc_id
+
+  tags = {
+    "Name"                                      = "node.${local.lower_name}"
+    "kubernetes.io/cluster/${local.lower_name}" = "owned"
+  }
+}
+
+resource "aws_security_group" "worker-internal" {
+  name        = "node-internal.${local.lower_name}"
+  description = "Set rules for controlling access within a cluster."
 
   vpc_id = var.vpc_id
 
@@ -13,106 +25,24 @@ resource "aws_security_group" "worker" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description = "Allow communication between worker nodes"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+  }
+
+  ingress {
+    description     = "Allow communication between master nodes and worker nodes"
+    security_groups = [aws_security_group.cluster.id]
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+  }
+
   tags = {
-    "Name"                                      = "nodes.${local.lower_name}"
+    "Name"                                      = "node-internal.${local.lower_name}"
     "kubernetes.io/cluster/${local.lower_name}" = "owned"
   }
 }
-
-resource "aws_security_group_rule" "worker-ingress-self" {
-  description              = "Allow worker to communicate with each other"
-  security_group_id        = aws_security_group.worker.id
-  source_security_group_id = aws_security_group.worker.id
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "worker-ingress-cluster" {
-  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
-  security_group_id        = aws_security_group.worker.id
-  source_security_group_id = aws_security_group.cluster.id
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "worker-ingress-sg" {
-  description              = "Allow workstation to communicate with the cluster API Server"
-  security_group_id        = aws_security_group.worker.id
-  # source_security_group_id = var.worker_sg_id != "" ? var.worker_sg_id : data.aws_security_group.worker_sg_id.id
-  source_security_group_id = var.worker_sg_id
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  type                     = "ingress"
-}
-
-
-
-
-# resource "aws_security_group" "worker" {
-#   name        = "nodes.${local.lower_name}"
-#   description = "Security group for all worker nodes in the cluster"
-
-#   vpc_id = var.vpc_id
-
-#   egress {
-#     from_port   = 0
-#     to_port     = 0
-#     protocol    = "-1"
-#     cidr_blocks = ["0.0.0.0/0"]
-#   }
-
-#   ingress {
-#     description = "Allow worker to communicate with each other"
-#     from_port   = 0
-#     to_port     = 0
-#     protocol    = "-1"
-#     self        = true
-#   }
-
-#   ingress {
-#     description     = "Allow worker Kubernetes and pods to receive communication from the cluster control plane"
-#     security_groups = [aws_security_group.cluster.id]
-#     from_port       = 0
-#     to_port         = 0
-#     protocol        = "-1"
-#   }
-
-# #   ingress {
-# #     description = "Allow worker to communicate with the cluster API Server"
-# #     cidr_blocks = local.allow_ips
-# #     from_port   = 22
-# #     to_port     = 22
-# #     protocol    = "tcp"
-# #   }
-
-#   ingress {
-#     description     = "Allow worker Kubernetes and pods to receive communication from the ALB for the public nginx ingress"
-#     security_groups = [aws_security_group.alb.id]
-#     from_port       = 0
-#     to_port         = 0
-#     protocol        = "-1"
-#   }
-
-
-# #   ingress {
-# #     description     = "Allow worker Kubernetes and pods to receive communication from the cluster control plane"
-# #     security_groups = [
-# #         var.worker_sg_id != "" ? var.worker_sg_id : data.aws_security_group.worker_sg_id.id,
-# #         ]
-# #     from_port       = 0
-# #     to_port         = 0
-# #     protocol        = "-1"
-# #   }
-        
-
-
-#   tags = {
-#     "Name"                                        = "nodes.${local.lower_name}"
-#     "kubernetes.io/cluster/${local.lower_name}" = "owned"
-#   }
-# }

--- a/modules/securitygroup-inline/outputs.tf
+++ b/modules/securitygroup-inline/outputs.tf
@@ -1,4 +1,7 @@
 
 output "sg_id" {
-  value = "${aws_security_group.this.id}"
+  value = "${aws_security_group.node-ingress.id}"
+}
+output "svc_sg_id" {
+  value = "${aws_security_group.service.id}"
 }

--- a/modules/securitygroup-inline/resource-sg.tf
+++ b/modules/securitygroup-inline/resource-sg.tf
@@ -1,44 +1,80 @@
 # security group
 
-resource "aws_security_group" "this" {
-    name        = "${var.sg_name}.${local.lower_name}"
-    description = "${var.sg_desc}"
+# For ALB
+resource "aws_security_group" "service" {
+  name        = "service.${local.lower_name}"
+  description = "Security group for a load balancer"
 
-    vpc_id = "${var.vpc_id}"
+  vpc_id = "${var.vpc_id}"
 
-    egress {
-        from_port   = 0
-        to_port     = 0
-        protocol    = "-1"
-        cidr_blocks = ["0.0.0.0/0"]
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "http"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "https"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name      = "service.${local.lower_name}"
+    SG_Groups = "${local.lower_name}"
+  }
+}
+
+resource "aws_security_group" "node-ingress" {
+  name        = "${var.sg_name}.${local.lower_name}"
+  description = "Set rules for controlling access from outside to the worker nodes"
+
+  vpc_id = "${var.vpc_id}"
+
+  ingress {
+    description     = "Allow communication with the load balancer"
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = [aws_security_group.service.id]
+  }
+
+  dynamic "ingress" {
+    for_each = var.source_sg_cidrs
+    content {
+      description = ingress.value["desc"]
+      from_port   = ingress.value["from"]
+      to_port     = ingress.value["to"]
+      protocol    = ingress.value["protocol"]
+      cidr_blocks = ingress.value["cidrs"]
     }
+  }
 
-    dynamic "ingress" {
-        for_each = var.source_sg_cidrs
-        content {
-            description     = ingress.value["desc"]
-            from_port       = ingress.value["from"]
-            to_port         = ingress.value["to"]
-            protocol        = ingress.value["protocol"]
-            cidr_blocks     = ingress.value["cidrs"]
-        }
+  dynamic "ingress" {
+    for_each = var.source_sg_ids
+    content {
+      description     = ingress.value["desc"]
+      from_port       = ingress.value["from"]
+      to_port         = ingress.value["to"]
+      protocol        = ingress.value["protocol"]
+      security_groups = ingress.value["security_groups"]
     }
+  }
 
-    dynamic "ingress" {
-        for_each = var.source_sg_ids
-        content {
-            description     = ingress.value["desc"]
-            from_port       = ingress.value["from"]
-            to_port         = ingress.value["to"]
-            protocol        = ingress.value["protocol"]
-            security_groups = ingress.value["security_groups"]
-        }
-    }
-
-    tags = {
-        Name = "${var.sg_name}.${local.lower_name}"
-        SG_Groups = "${local.lower_name}"
-
-    }
+  tags = {
+    Name      = "${var.sg_name}.${local.lower_name}"
+    SG_Groups = "${local.lower_name}"
+  }
 
 }

--- a/templates/eks/cluster-security-group.tf
+++ b/templates/eks/cluster-security-group.tf
@@ -35,11 +35,11 @@ resource "aws_security_group" "cluster" {
   }
 
   ingress {
-    description         = "Allow workstation to communicate with the cluster API server"
-    cidr_blocks         = local.allow_ips
-    from_port           = 443
-    to_port             = 443
-    protocol            = "tcp"
+    description = "Allow workstation to communicate with the cluster API server"
+    cidr_blocks = local.allow_ips
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
   }
 
   tags = {

--- a/templates/eks/cluster-security-group.tf
+++ b/templates/eks/cluster-security-group.tf
@@ -35,11 +35,11 @@ resource "aws_security_group" "cluster" {
   }
 
   ingress {
-    description = "Allow workstation to communicate with the cluster API server"
-    cidr_blocks = local.allow_ips
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
+    description         = "Allow workstation to communicate with the cluster API server"
+    cidr_blocks         = local.allow_ips
+    from_port           = 443
+    to_port             = 443
+    protocol            = "tcp"
   }
 
   tags = {


### PR DESCRIPTION
- Create a separate reference S/G (node) for the Worker.
- Create a separate node-internal (S/G) for access control within the cluster and an S/Gnode-ingress for inbound access control.
- Inbound access control S/G (node-ingress) and S/G (service) for load balancers are prepared before cluster creation.