### PR TITLE
modify security group settings

### DIFF
--- a/modules/eks-compute/outputs.tf
+++ b/modules/eks-compute/outputs.tf
@@ -11,5 +11,5 @@ output "target_group_arn" {
   value = "${aws_lb_target_group.tg_http.arn}"
 }
 output "worknode_security_group_id" {
-  value = "${aws_security_group.worker.id}"
+  value = "${aws_security_group.worker-internal.id}"
 }

--- a/modules/eks-compute/resource-cluster-sg.tf
+++ b/modules/eks-compute/resource-cluster-sg.tf
@@ -2,7 +2,7 @@
 
 resource "aws_security_group" "cluster" {
   name        = "masters.${local.lower_name}"
-  description = "Cluster communication with worker nodes"
+  description = "Cluster security group for egress rules"
 
   vpc_id = var.vpc_id
 
@@ -13,28 +13,17 @@ resource "aws_security_group" "cluster" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description     = "Allow node to communicate with the cluster API Server"
+    security_groups = [aws_security_group.worker.id]
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+  }
+
   tags = {
     "Name"                                      = "masters.${local.lower_name}"
     "kubernetes.io/cluster/${local.lower_name}" = "owned"
   }
 }
 
-resource "aws_security_group_rule" "cluster-ingress-node-https" {
-  description              = "Allow node to communicate with the cluster API Server"
-  security_group_id        = aws_security_group.cluster.id
-  source_security_group_id = aws_security_group.worker.id
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  type                     = "ingress"
-}
-
-# resource "aws_security_group_rule" "cluster-ingress-admin-https" {
-#   description       = "Allow workstation to communicate with the cluster API Server"
-#   security_group_id = aws_security_group.cluster.id
-#   cidr_blocks       = local.allow_ips
-#   from_port         = 443
-#   to_port           = 443
-#   protocol          = "tcp"
-#   type              = "ingress"
-# }

--- a/modules/eks-compute/resource-cluster.tf
+++ b/modules/eks-compute/resource-cluster.tf
@@ -6,10 +6,10 @@ resource "aws_eks_cluster" "cluster" {
   version  = var.kubernetes_version
 
   vpc_config {
-    subnet_ids         = var.subnet_ids
+    subnet_ids = var.subnet_ids
     security_group_ids = [
-        aws_security_group.cluster.id,
-      ]
+      aws_security_group.cluster.id,
+    ]
   }
 
   depends_on = [

--- a/modules/eks-compute/resource-worker-mixed.tf
+++ b/modules/eks-compute/resource-worker-mixed.tf
@@ -29,6 +29,8 @@ resource "aws_launch_template" "worker-mixed" {
     associate_public_ip_address = var.associate_public_ip_address
     security_groups = [
       aws_security_group.worker.id,
+      aws_security_group.worker-internal.id,
+      var.worker_sg_id, #worker-ingress.id
     ]
   }
 }
@@ -43,7 +45,7 @@ resource "aws_autoscaling_group" "worker-mixed" {
 
   vpc_zone_identifier = var.subnet_ids
 
-  enabled_metrics = [ 
+  enabled_metrics = [
     "GroupDesiredCapacity",
     "GroupInServiceInstances",
     "GroupMaxSize",
@@ -53,7 +55,7 @@ resource "aws_autoscaling_group" "worker-mixed" {
     "GroupTerminatingInstances",
     "GroupTotalInstances",
   ]
-  
+
   target_group_arns = [
     aws_lb_target_group.tg_http.arn,
   ]

--- a/modules/eks-compute/resource-worker-sg.tf
+++ b/modules/eks-compute/resource-worker-sg.tf
@@ -6,6 +6,18 @@ resource "aws_security_group" "worker" {
 
   vpc_id = var.vpc_id
 
+  tags = {
+    "Name"                                      = "nodes.${local.lower_name}"
+    "kubernetes.io/cluster/${local.lower_name}" = "owned"
+  }
+}
+
+resource "aws_security_group" "worker-internal" {
+  name        = "node-internal.${local.lower_name}"
+  description = "Set rules for controlling access within a cluster."
+
+  vpc_id = var.vpc_id
+
   egress {
     from_port   = 0
     to_port     = 0
@@ -13,106 +25,24 @@ resource "aws_security_group" "worker" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description = "Allow communication between worker nodes"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+  }
+
+  ingress {
+    description     = "Allow communication between master nodes and worker nodes"
+    security_groups = [aws_security_group.cluster.id]
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+  }
+
   tags = {
-    "Name"                                      = "nodes.${local.lower_name}"
+    "Name"                                      = "node-internal.${local.lower_name}"
     "kubernetes.io/cluster/${local.lower_name}" = "owned"
   }
 }
-
-resource "aws_security_group_rule" "worker-ingress-self" {
-  description              = "Allow worker to communicate with each other"
-  security_group_id        = aws_security_group.worker.id
-  source_security_group_id = aws_security_group.worker.id
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "worker-ingress-cluster" {
-  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
-  security_group_id        = aws_security_group.worker.id
-  source_security_group_id = aws_security_group.cluster.id
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "worker-ingress-sg" {
-  description              = "Allow workstation to communicate with the cluster API Server"
-  security_group_id        = aws_security_group.worker.id
-  # source_security_group_id = var.worker_sg_id != "" ? var.worker_sg_id : data.aws_security_group.worker_sg_id.id
-  source_security_group_id = var.worker_sg_id
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  type                     = "ingress"
-}
-
-
-
-
-# resource "aws_security_group" "worker" {
-#   name        = "nodes.${local.lower_name}"
-#   description = "Security group for all worker nodes in the cluster"
-
-#   vpc_id = var.vpc_id
-
-#   egress {
-#     from_port   = 0
-#     to_port     = 0
-#     protocol    = "-1"
-#     cidr_blocks = ["0.0.0.0/0"]
-#   }
-
-#   ingress {
-#     description = "Allow worker to communicate with each other"
-#     from_port   = 0
-#     to_port     = 0
-#     protocol    = "-1"
-#     self        = true
-#   }
-
-#   ingress {
-#     description     = "Allow worker Kubernetes and pods to receive communication from the cluster control plane"
-#     security_groups = [aws_security_group.cluster.id]
-#     from_port       = 0
-#     to_port         = 0
-#     protocol        = "-1"
-#   }
-
-# #   ingress {
-# #     description = "Allow worker to communicate with the cluster API Server"
-# #     cidr_blocks = local.allow_ips
-# #     from_port   = 22
-# #     to_port     = 22
-# #     protocol    = "tcp"
-# #   }
-
-#   ingress {
-#     description     = "Allow worker Kubernetes and pods to receive communication from the ALB for the public nginx ingress"
-#     security_groups = [aws_security_group.alb.id]
-#     from_port       = 0
-#     to_port         = 0
-#     protocol        = "-1"
-#   }
-
-
-# #   ingress {
-# #     description     = "Allow worker Kubernetes and pods to receive communication from the cluster control plane"
-# #     security_groups = [
-# #         var.worker_sg_id != "" ? var.worker_sg_id : data.aws_security_group.worker_sg_id.id,
-# #         ]
-# #     from_port       = 0
-# #     to_port         = 0
-# #     protocol        = "-1"
-# #   }
-        
-
-
-#   tags = {
-#     "Name"                                        = "nodes.${local.lower_name}"
-#     "kubernetes.io/cluster/${local.lower_name}" = "owned"
-#   }
-# }

--- a/modules/eks-network-migration/data.tf
+++ b/modules/eks-network-migration/data.tf
@@ -4,8 +4,12 @@ data "aws_route53_zone" "selected" {
   private_zone = false
 }
 
-data "aws_security_group" "worker_sg_id" {
-  name = "node.${local.lower_name}"
+data "aws_security_group" "worker_sg" {
+  name = "nodes.${local.lower_name}"
+}
+
+data "aws_security_group" "service_sg" {
+  name = "service.${local.lower_name}"
 }
 
 data "aws_lb_target_group" "tg_http" {

--- a/modules/eks-network-migration/resource-alb.tf
+++ b/modules/eks-network-migration/resource-alb.tf
@@ -6,8 +6,8 @@ resource "aws_lb" "main" {
   internal           = false
   load_balancer_type = "application"
   security_groups    = [
-                        aws_security_group.alb.id, 
-                        var.worker_sg_id != "" ? var.worker_sg_id : data.aws_security_group.worker_sg_id.id,
+                        data.aws_security_group.service_sg.id, 
+                        var.worker_sg_id != "" ? var.worker_sg_id : data.aws_security_group.worker_sg.id,
                       ]
   subnets            = var.public_subnet_ids
 
@@ -19,36 +19,6 @@ resource "aws_lb" "main" {
   tags = {
       "Name" = "${local.upper_name}-ALB"
   }    
-}
-
-resource "aws_security_group" "alb" {
-  vpc_id = var.vpc_id
-  name   = "${local.upper_name}-ALB"
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "TCP"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "TCP"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-      "Name" = "${local.upper_name}-ALB"
-  }
 }
 
 resource "aws_lb_listener" "frontend_http" {

--- a/modules/eks-network-migration/resource-alb.tf
+++ b/modules/eks-network-migration/resource-alb.tf
@@ -6,8 +6,7 @@ resource "aws_lb" "main" {
   internal           = false
   load_balancer_type = "application"
   security_groups    = [
-                        data.aws_security_group.service_sg.id, 
-                        var.worker_sg_id != "" ? var.worker_sg_id : data.aws_security_group.worker_sg.id,
+                        data.aws_security_group.service_sg.id
                       ]
   subnets            = var.public_subnet_ids
 

--- a/modules/eks-network-migration/resource-route53.tf
+++ b/modules/eks-network-migration/resource-route53.tf
@@ -9,7 +9,7 @@ resource "aws_route53_record" "address_bset" {
     weight = var.weighted_routing_new
   }
 
-  set_identifier = "subSet"
+  set_identifier = var.name
 
   alias {
       name = aws_lb.main.dns_name
@@ -17,8 +17,6 @@ resource "aws_route53_record" "address_bset" {
       evaluate_target_health = true
   }
 }
-
-
 
 resource "aws_route53_record" "address_represent" {
   zone_id = data.aws_route53_zone.selected.zone_id
@@ -29,7 +27,7 @@ resource "aws_route53_record" "address_represent" {
     weight = var.weighted_routing_represent
   }
 
-  set_identifier = "NewSet"
+  set_identifier = var.name
 
   alias {
       name = aws_lb.main.dns_name

--- a/modules/securitygroup-inline/outputs.tf
+++ b/modules/securitygroup-inline/outputs.tf
@@ -1,4 +1,7 @@
 
 output "sg_id" {
-  value = "${aws_security_group.this.id}"
+  value = "${aws_security_group.node-ingress.id}"
+}
+output "svc_sg_id" {
+  value = "${aws_security_group.service.id}"
 }


### PR DESCRIPTION
- Create a separate reference S/G (node) for the Worker.
- Create a separate node-internal (S/G) for access control within the cluster and an S/Gnode-ingress for inbound access control.
- Inbound access control S/G (node-ingress) and S/G (service) for load balancers are prepared before cluster creation.
- Modify alb settins